### PR TITLE
[FIX]: scripts/jonas issue where reward was not added on jackpot roll

### DIFF
--- a/script/AIScripts/citizens/jonas.ais
+++ b/script/AIScripts/citizens/jonas.ais
@@ -197,6 +197,7 @@ handler:
                                 DeleteItem1(talker, @green_moss_bundle, OwnItemCount(talker, @green_moss_bundle));
                                 DeleteItem1(talker, @brown_moss_bundle, OwnItemCount(talker, @brown_moss_bundle));
                                 DeleteItem1(talker, @monster_eye_meat, OwnItemCount(talker, @monster_eye_meat));
+                                GiveItem1(talker, @jonas_steak_dish5, 1);
                                 SoundEffect(talker, "ItemSound.quest_jackpot");
                             }
                             else


### PR DESCRIPTION
* the touched if-else branch handles the scenario when the player brought back all the best ingredients and his random-roll was "lucky" but giving the item `jonas_steak_dish5` was missing